### PR TITLE
Downgrade owasp version [8.4.3 -> 8.4.0]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ gradle-versions = "0.44.0"
 jfrog = "4.29.0"
 kotest = "5.8.0"
 kotlin = "1.9.21"
-owasp-dependency = "8.4.3"
+owasp-dependency = "8.4.0"
 shadow = "8.0.0"
 test-logger = "3.2.0"
 


### PR DESCRIPTION
[patch]
Version 8.4.3 included a jackson dependency which required Java 19, resulting in build failures in dependent projects.