### PR TITLE
Re-enable artifactoryPublish gradle task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 # This is required to avoid megalinter spamming each repository with lint configurations
 .ansible-lint
 .checkmake.ini
+.ecrc
 .flake8
+.gitleaks.toml
 .golangci.yml
 .htmlhintrc
 .jsonlintrc

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.adarshr.gradle.testlogger.theme.ThemeType
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 import org.owasp.dependencycheck.gradle.tasks.AbstractAnalyze
 import org.owasp.dependencycheck.gradle.tasks.Aggregate
 import org.owasp.dependencycheck.gradle.tasks.Analyze
@@ -131,12 +130,6 @@ fun AbstractAnalyze.setCustomConfiguration() {
 /*
  * Publishing
  */
-tasks {
-    named<ArtifactoryTask>("artifactoryPublish") {
-        skip = true
-    }
-}
-
 fun jvmProjects() = subprojects.filter { File(it.projectDir, "src").isDirectory }
 
 configure(jvmProjects()) {


### PR DESCRIPTION
## 📝 Description

This was skipped in a previous commit, resulting in no artifacts being pushed to jfrog. As per the documentation, this task is the main task of the artifactory-gradle-plugin and needs to be run in order for the plugin to do anything useful.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
