### PR TITLE
Remove explicit group and version from publishing block [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/devxp/kotlin-application.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-application.gradle.kts
@@ -14,6 +14,13 @@ plugins {
 /*
  * Publishing
  */
+publishing {
+    publications {
+        create<MavenPublication>(rootProject.name) {
+            from(components["java"])
+        }
+    }
+}
 artifactory {
     clientConfig.isIncludeEnvVars = true
 

--- a/src/main/kotlin/no/elhub/devxp/kotlin-application.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-application.gradle.kts
@@ -16,7 +16,7 @@ plugins {
  */
 publishing {
     publications {
-        create<MavenPublication>(rootProject.name) {
+        create<MavenPublication>("maven") {
             from(components["java"])
         }
     }

--- a/src/main/kotlin/no/elhub/devxp/kotlin-library.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-library.gradle.kts
@@ -14,7 +14,7 @@ plugins {
  */
 publishing {
     publications {
-        create<MavenPublication>(rootProject.name) {
+        create<MavenPublication>("maven") {
             from(components["java"])
         }
     }

--- a/src/main/kotlin/no/elhub/devxp/kotlin-library.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-library.gradle.kts
@@ -12,6 +12,14 @@ plugins {
 /**
  * Publishing
  */
+publishing {
+    publications {
+        create<MavenPublication>(rootProject.name) {
+            from(components["java"])
+        }
+    }
+}
+
 artifactory {
     clientConfig.isIncludeEnvVars = true
 


### PR DESCRIPTION
## 📝 Description

The rootProject.x attributes are not available at the time the plugin is initialized, so setting them here just sets them to emptystring

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
