### PR TITLE
Bump OWASP to 12.1.1 to resolve NVD data parse error [minor]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ jfrog = "5.2.5"
 kotest = "5.9.1"
 kotlin = "2.1.20"
 kotlin-dsl = "5.2.0"
-owasp-dependency = "12.1.0"
+owasp-dependency = "12.1.1"
 shadow = "8.3.6"
 test-logger = "4.0.0"
 


### PR DESCRIPTION
Encounter parse error "com.fasterxml.jackson.core.JsonParseException: Unexpected character (']' (code 93))" during OWASP check
Bumping owasp to 12.1.1 should fix the issue based on what is written in
the DependencyCheck changelog: https://github.com/dependency-check/DependencyCheck/blob/main/CHANGELOG.md
