### PR TITLE
Update coverage handling

### DIFF
--- a/src/main/kotlin/no/elhub/devxp/ProxyConfig.kt
+++ b/src/main/kotlin/no/elhub/devxp/ProxyConfig.kt
@@ -1,0 +1,27 @@
+package no.elhub.devxp
+
+import org.owasp.dependencycheck.gradle.tasks.AbstractAnalyze
+
+fun AbstractAnalyze.setCustomConfiguration() {
+    doFirst {
+        val proxyHost = project.findProperty("proxyHost")
+        val proxyPort = project.findProperty("proxyPort")
+        val nonProxyHosts = project.findProperty("nonProxyHosts")
+        listOf("http", "https").forEach {
+            if (proxyHost != null && proxyPort != null) {
+                System.setProperty("$it.proxyHost", proxyHost.toString())
+                System.setProperty("$it.proxyPort", proxyPort.toString())
+            }
+            if (nonProxyHosts != null) {
+                System.setProperty("$it.nonProxyHosts", nonProxyHosts.toString())
+            }
+        }
+    }
+    doLast {
+        listOf("http", "https").forEach {
+            System.clearProperty("$it.proxyPort")
+            System.clearProperty("$it.proxyHost")
+            System.clearProperty("$it.nonProxyHosts")
+        }
+    }
+}

--- a/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
@@ -7,7 +7,6 @@ import com.adarshr.gradle.testlogger.theme.ThemeType
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.owasp.dependencycheck.gradle.tasks.AbstractAnalyze
 import org.owasp.dependencycheck.gradle.tasks.Aggregate
 import org.owasp.dependencycheck.gradle.tasks.Analyze
 import org.owasp.dependencycheck.reporting.ReportGenerator
@@ -90,7 +89,8 @@ dependencyCheck {
 
         // Teamcity agents running .NET version too old for .NET Assembly Analyzer. Needs to be disabled until agents are updated
         assemblyEnabled = false
-        // Needs to be disabled until "search.maven.org" is whitelisted in squid. Owasp 12.1.0 uses this to populate artifact metadata for better detection, but the effect should be minimal
+        // Needs to be disabled until "search.maven.org" is whitelisted in squid. Owasp 12.1.0 uses this to populate artifact
+        // metadata for better detection, but the effect should be minimal
         centralEnabled = false
         retirejs {
             enabled = false
@@ -112,30 +112,6 @@ tasks.withType<Analyze> {
 
 tasks.withType<Aggregate> {
     setCustomConfiguration()
-}
-
-fun AbstractAnalyze.setCustomConfiguration() {
-    doFirst {
-        val proxyHost = project.findProperty("proxyHost")
-        val proxyPort = project.findProperty("proxyPort")
-        val nonProxyHosts = project.findProperty("nonProxyHosts")
-        listOf("http", "https").forEach {
-            if (proxyHost != null && proxyPort != null) {
-                System.setProperty("$it.proxyHost", proxyHost.toString())
-                System.setProperty("$it.proxyPort", proxyPort.toString())
-            }
-            if (nonProxyHosts != null) {
-                System.setProperty("$it.nonProxyHosts", nonProxyHosts.toString())
-            }
-        }
-    }
-    doLast {
-        listOf("http", "https").forEach {
-            System.clearProperty("$it.proxyPort")
-            System.clearProperty("$it.proxyHost")
-            System.clearProperty("$it.nonProxyHosts")
-        }
-    }
 }
 
 /*

--- a/src/test/kotlin/no/elhub/devxp/KotlinApplicationTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinApplicationTest.kt
@@ -1,11 +1,9 @@
 package no.elhub.devxp
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.testkit.runner.UnexpectedBuildFailure
 
 class KotlinApplicationTest : DescribeSpec({
     val testInstance = TestInstance()
@@ -77,10 +75,10 @@ class KotlinApplicationTest : DescribeSpec({
 
     describe("When the project publishes artifacts") {
 
-        it("should fail on the artifactoryPublish task if host does not exist") {
-            shouldThrow<UnexpectedBuildFailure> {
-                testInstance.runTask("artifactoryPublish")
-            }
+        it("the publish task should run artifactoryPublish") {
+            val result = testInstance.runTask("publish", "--dry-run")
+            result.output shouldContain ":artifactoryPublish"
+            result.output shouldContain "BUILD SUCCESSFUL"
         }
     }
 

--- a/src/test/kotlin/no/elhub/devxp/KotlinCoreTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinCoreTest.kt
@@ -85,6 +85,34 @@ class KotlinCoreTest : DescribeSpec({
         }
     }
 
+    describe("When jacocoTestReport is run with this plugin") {
+
+        it("should run test and jacocoTestReport tasks") {
+            val result = testInstance.runTask("jacocoTestReport", "--dry-run")
+            result.output shouldContain ":test"
+            result.output shouldContain ":jacocoTestReport"
+            result.output shouldContain "BUILD SUCCESSFUL"
+        }
+    }
+
+    describe("When dependencyCheckAnalyze is run with this plugin") {
+
+        it("should exercise the dependency check") {
+            val result = testInstance.runTask("dependencyCheckAnalyze", "--dry-run")
+            result.output shouldContain ":dependencyCheckAnalyze"
+            result.output shouldContain "BUILD SUCCESSFUL"
+        }
+    }
+
+    describe("When teamCityCheck is run with this plugin") {
+
+        it("should exercise the dependency check") {
+            val result = testInstance.runTask("teamcityCheck", "--dry-run")
+            result.output shouldContain ":teamcityCheck"
+            result.output shouldContain "BUILD SUCCESSFUL"
+        }
+    }
+
     afterSpec {
         testInstance.dispose()
     }

--- a/src/test/kotlin/no/elhub/devxp/KotlinLibraryTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinLibraryTest.kt
@@ -1,11 +1,9 @@
 package no.elhub.devxp
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.testkit.runner.UnexpectedBuildFailure
 
 class KotlinLibraryTest : DescribeSpec({
     val testInstance = TestInstance()
@@ -67,10 +65,10 @@ class KotlinLibraryTest : DescribeSpec({
 
     describe("When the project publishes artifacts") {
 
-        it("should fail on the artifactoryPublish task if host does not exist") {
-            shouldThrow<UnexpectedBuildFailure> {
-                testInstance.runTask("artifactoryPublish")
-            }
+        it("the publish task should run artifactoryPublish") {
+            val result = testInstance.runTask("publish", "--dry-run")
+            result.output shouldContain ":artifactoryPublish"
+            result.output shouldContain "BUILD SUCCESSFUL"
         }
     }
 

--- a/src/test/kotlin/no/elhub/devxp/KotlinServiceTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinServiceTest.kt
@@ -1,11 +1,9 @@
 package no.elhub.devxp
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.testkit.runner.UnexpectedBuildFailure
 
 class KotlinServiceTest : DescribeSpec({
     val testInstance = TestInstance()
@@ -63,10 +61,10 @@ class KotlinServiceTest : DescribeSpec({
 
     describe("When the project publishes artifacts") {
 
-        it("should fail on the artifactoryPublish task if host does not exist") {
-            shouldThrow<UnexpectedBuildFailure> {
-                testInstance.runTask("artifactoryPublish")
-            }
+        it("the publish task should run artifactoryPublish") {
+            val result = testInstance.runTask("publish", "--dry-run")
+            result.output shouldContain ":artifactoryPublish"
+            result.output shouldContain "BUILD SUCCESSFUL"
         }
     }
 

--- a/src/test/kotlin/no/elhub/devxp/ProxyConfigTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/ProxyConfigTest.kt
@@ -1,0 +1,57 @@
+package no.elhub.devxp
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.gradle.testfixtures.ProjectBuilder
+import org.owasp.dependencycheck.gradle.tasks.Analyze
+
+class ProxyConfigTest : DescribeSpec({
+
+    describe("setCustomConfiguration") {
+
+        it("should set proxy system properties when project properties are present") {
+            val project = ProjectBuilder.builder().build()
+            project.extensions.extraProperties.set("proxyHost", "proxy.example.com")
+            project.extensions.extraProperties.set("proxyPort", "8080")
+            project.extensions.extraProperties.set("nonProxyHosts", "localhost|*.internal")
+
+            val task = project.tasks.create("analyze", Analyze::class.java)
+            task.setCustomConfiguration()
+
+            // Execute doFirst action
+            task.actions.first().execute(task)
+
+            System.getProperty("http.proxyHost") shouldBe "proxy.example.com"
+            System.getProperty("http.proxyPort") shouldBe "8080"
+            System.getProperty("http.nonProxyHosts") shouldBe "localhost|*.internal"
+            System.getProperty("https.proxyHost") shouldBe "proxy.example.com"
+            System.getProperty("https.proxyPort") shouldBe "8080"
+            System.getProperty("https.nonProxyHosts") shouldBe "localhost|*.internal"
+
+            // Execute doLast action
+            task.actions.last().execute(task)
+
+            System.getProperty("http.proxyHost") shouldBe null
+            System.getProperty("http.proxyPort") shouldBe null
+            System.getProperty("http.nonProxyHosts") shouldBe null
+            System.getProperty("https.proxyHost") shouldBe null
+            System.getProperty("https.proxyPort") shouldBe null
+            System.getProperty("https.nonProxyHosts") shouldBe null
+        }
+
+        it("should not set proxy host/port when only one is present") {
+            val project = ProjectBuilder.builder().build()
+            project.extensions.extraProperties.set("proxyHost", "proxy.example.com")
+            project.extensions.extraProperties.set("nonProxyHosts", "localhost")
+
+            val task = project.tasks.create("analyze", Analyze::class.java)
+            task.setCustomConfiguration()
+
+            task.actions.first().execute(task)
+
+            System.getProperty("http.proxyHost") shouldBe null
+            System.getProperty("http.proxyPort") shouldBe null
+            System.getProperty("http.nonProxyHosts") shouldBe "localhost"
+        }
+    }
+})

--- a/src/test/kotlin/no/elhub/devxp/TestInstance.kt
+++ b/src/test/kotlin/no/elhub/devxp/TestInstance.kt
@@ -28,11 +28,11 @@ class TestInstance {
         )
     }
 
-    fun runTask(task: String): BuildResult =
+    fun runTask(task: String, vararg args: String): BuildResult =
         GradleRunner
             .create()
             .withProjectDir(projectDir.toFile())
-            .withArguments(task, "--stacktrace")
+            .withArguments(listOf(task, *args, "--stacktrace"))
             .withPluginClasspath()
             .build()
 


### PR DESCRIPTION
## 📝 Description

The prior approach to coverage has issues on the TeamCity server, and was
not ideal. This version breaks out some testable code into its own Kotlin file instead, and uses
"dry-run" for test runs.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
