### PR TITLE
Fix configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 version=1.0-SNAPSHOT


### PR DESCRIPTION
## 📝 Description

The gradle configuration cache is not compatible with the extractInfo job in publish. Disabled.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
