### PR TITLE
Remove minimize() from shadowJar task [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/devxp/kotlin-application.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-application.gradle.kts
@@ -63,7 +63,6 @@ tasks.shadowJar {
         )
     }
     mergeServiceFiles()
-    minimize()
 }
 
 tasks["assemble"].dependsOn(tasks.shadowJar)


### PR DESCRIPTION
## 🔗 Issue ID(s): TDX-1153, WOW-1760

This was added in version 8. The test-data tool breaks with this version (and newer ones), 7.11 still works fine. Overriding this minimize() to do nothing seems to fix it. It's probably possible to set up the correct excludes and such to make it work, but then it's better to leave it up to the owners of each project to set this up I think.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
