### PR TITLE
fix(ci): disable ossIndex in owasp [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
@@ -135,6 +135,7 @@ dependencyCheck {
             enabled = false
         }
         ossIndex {
+            enabled = false // We are IP banned from Sonatype likely due to too many requests. Remove this if a solution is found.
             username = System.getenv("SONATYPE_USERNAME")
             password = System.getenv("SONATYPE_API_TOKEN")
         }


### PR DESCRIPTION
## 📝 Description

Since we are IP banned by sonatype oss index, we need to disable it for now, and then potentially figure out how to limit our api calls.

## 🔗 Issue ID(s): [TDX-1554](https://elhub.atlassian.net/browse/TDX-1554)

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.


[TDX-1554]: https://elhub.atlassian.net/browse/TDX-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ