### PR TITLE
fix(core): refactor printCoverage to be compatible with configuration cache [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/devxp/coverage/CoverageReporter.kt
+++ b/src/main/kotlin/no/elhub/devxp/coverage/CoverageReporter.kt
@@ -1,10 +1,9 @@
 package no.elhub.devxp.coverage
 
-import org.gradle.api.Project
 import java.io.File
 import java.math.BigInteger
 
-class CoverageReporter(private val project: Project) {
+class CoverageReporter(private val reportFiles: List<File>) {
 
     data class CoverageMetrics(
         var instructionCovered: BigInteger = BigInteger.ZERO,
@@ -16,21 +15,12 @@ class CoverageReporter(private val project: Project) {
     fun generateReport() {
         val totalMetrics = CoverageMetrics()
 
-        val projectsToCheck = if (project.subprojects.isEmpty()) {
-            listOf(project)
-        } else {
-            project.subprojects
-        }
-
-        projectsToCheck.forEach { proj ->
-            val reportFile = proj.file("build/reports/jacoco/test/jacocoTestReport.xml")
-            if (reportFile.exists()) {
-                val projectMetrics = extractCoverage(reportFile)
-                totalMetrics.instructionCovered += projectMetrics.instructionCovered
-                totalMetrics.instructionMissed += projectMetrics.instructionMissed
-                totalMetrics.branchCovered += projectMetrics.branchCovered
-                totalMetrics.branchMissed += projectMetrics.branchMissed
-            }
+        reportFiles.forEach { reportFile ->
+            val projectMetrics = extractCoverage(reportFile)
+            totalMetrics.instructionCovered += projectMetrics.instructionCovered
+            totalMetrics.instructionMissed += projectMetrics.instructionMissed
+            totalMetrics.branchCovered += projectMetrics.branchCovered
+            totalMetrics.branchMissed += projectMetrics.branchMissed
         }
 
         printColoredReport(totalMetrics)

--- a/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
@@ -68,8 +68,23 @@ tasks.jacocoTestReport {
 
 tasks.register("printCoverage") {
     dependsOn(tasks.jacocoTestReport)
+
+    // For some projects, which use configuration-cache, we cannot inspect the project at execution time, so we cannot have this within doLast
+    val reportFiles: List<File> = run {
+        val projectsToCheck = if (project.subprojects.isEmpty()) {
+            listOf(project)
+        } else {
+            project.subprojects.toList()
+        }
+        projectsToCheck.map {
+            it.file("build/reports/jacoco/test/jacocoTestReport.xml")
+        }
+    }
+
+    val reports = objects.fileCollection().from(reportFiles)
+
     doLast {
-        CoverageReporter(project).generateReport()
+        CoverageReporter(reports.files.filter { it.exists() }).generateReport()
     }
 }
 

--- a/src/test/kotlin/no/elhub/devxp/coverage/CoverageReporterTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/coverage/CoverageReporterTest.kt
@@ -40,8 +40,9 @@ class CoverageReporterTest : FunSpec({
                 """.trimIndent()
             )
 
+
             val output = captureOutput {
-                CoverageReporter(project).generateReport()
+                CoverageReporter(listOf(reportFile)).generateReport()
             }
 
             output shouldContain "100%"
@@ -65,7 +66,7 @@ class CoverageReporterTest : FunSpec({
             )
 
             val output = captureOutput {
-                CoverageReporter(project).generateReport()
+                CoverageReporter(listOf(reportFile)).generateReport()
             }
 
             output shouldContain "0%"
@@ -88,7 +89,7 @@ class CoverageReporterTest : FunSpec({
             )
 
             val output = captureOutput {
-                CoverageReporter(project).generateReport()
+                CoverageReporter(listOf(reportFile)).generateReport()
             }
 
             output shouldContain "80%"
@@ -99,10 +100,13 @@ class CoverageReporterTest : FunSpec({
             val subproject1 = ProjectBuilder.builder().withParent(rootProject).withName("sub1").build()
             val subproject2 = ProjectBuilder.builder().withParent(rootProject).withName("sub2").build()
 
+            val reportFiles = mutableListOf<File>()
+
             listOf(subproject1, subproject2).forEach { proj ->
                 val reportDir = File(proj.projectDir, "build/reports/jacoco/test")
                 reportDir.mkdirs()
-                File(reportDir, "jacocoTestReport.xml").writeText(
+                val file = File(reportDir, "jacocoTestReport.xml")
+                file.writeText(
                     """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <report name="test">
@@ -111,20 +115,19 @@ class CoverageReporterTest : FunSpec({
                 </report>
                     """.trimIndent()
                 )
+                reportFiles.add(file)
             }
 
             val output = captureOutput {
-                CoverageReporter(rootProject).generateReport()
+                CoverageReporter(reportFiles).generateReport()
             }
 
             output shouldContain "90%"
         }
 
         test("should handle missing report files gracefully") {
-            val project = ProjectBuilder.builder().build()
-
             val output = captureOutput {
-                CoverageReporter(project).generateReport()
+                CoverageReporter(emptyList()).generateReport()
             }
 
             output shouldContain "0%"
@@ -147,7 +150,7 @@ class CoverageReporterTest : FunSpec({
             )
 
             val output = captureOutput {
-                CoverageReporter(project).generateReport()
+                CoverageReporter(listOf(reportFile)).generateReport()
             }
 
             output shouldContain "\u001B[32m"
@@ -171,7 +174,7 @@ class CoverageReporterTest : FunSpec({
             )
 
             val output = captureOutput {
-                CoverageReporter(project).generateReport()
+                CoverageReporter(listOf(reportFile)).generateReport()
             }
 
             output shouldContain "\u001B[31m"


### PR DESCRIPTION
## 📝 Description

When configuration cache is enabled, we are not allowed to access the project at execution time (e.g. within doLast). Therefore, we calculate everything having to do with project at configuration time, and then pass those values into the function executed in doLast.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
