### PR TITLE
fix: Bump owasp dependency scanner version [patch]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jacoco = "0.8.14"
 jfrog = "6.0.4"
 kotest = "6.1.7"
 kotlin = "2.3.20"
-owasp-dependency = "12.2.0"
+owasp-dependency = "12.2.2"
 shadow = "9.4.0"
 test-logger = "4.0.0"
 


### PR DESCRIPTION

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
