### PR TITLE
feat+fix: add checks for cyclonedx + make sure version is updated [minor]

### DIFF
--- a/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
+++ b/src/main/kotlin/no/elhub/devxp/kotlin-core.gradle.kts
@@ -165,6 +165,11 @@ dependencyCheck {
     }
 }
 
+tasks.named("cyclonedxBom") {
+    group = "build"
+    description = "Generates a CycloneDX SBOM for the project."
+}
+
 tasks.withType<Analyze> {
     setCustomConfiguration()
 }

--- a/src/test/kotlin/no/elhub/devxp/KotlinApplicationTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinApplicationTest.kt
@@ -42,7 +42,8 @@ class KotlinApplicationTest : FunSpec({
                 "application",
                 "com.github.johnrengelman.shadow",
                 "com.jfrog.artifactory",
-                "maven-publish"
+                "maven-publish",
+                "org.cyclonedx.bom",
             )
 
         pluginsIncluded.forEach { plugin ->
@@ -76,6 +77,7 @@ class KotlinApplicationTest : FunSpec({
                 "assemble",
                 "dependencyUpdates",
                 "dependencyCheckAnalyze",
+                "cyclonedxBom",
                 "jacocoTestReport",
                 "test",
                 "publish",

--- a/src/test/kotlin/no/elhub/devxp/KotlinCoreTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinCoreTest.kt
@@ -198,7 +198,7 @@ class KotlinCoreTest : FunSpec({
 
     context("When cyclonedxBom is run with this plugin") {
 
-        xtest("should work") {
+        test("should work") {
             val result = testInstance.runTask("cyclonedxBom")
             result.output shouldContain ":cyclonedxBom"
             result.output shouldContain "BUILD SUCCESSFUL"

--- a/src/test/kotlin/no/elhub/devxp/KotlinCoreTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinCoreTest.kt
@@ -35,6 +35,7 @@ class KotlinCoreTest : FunSpec({
                 "com.adarshr.test-logger",
                 "org.owasp.dependencycheck",
                 "org.jetbrains.dokka",
+                "org.cyclonedx.bom",
             )
 
         pluginsIncluded.forEach { plugin ->
@@ -73,6 +74,7 @@ class KotlinCoreTest : FunSpec({
                 "assemble",
                 "dependencyUpdates",
                 "dependencyCheckAnalyze",
+                "cyclonedxBom",
                 "dokkaGenerate",
                 "dokkaGenerateHtml",
                 "jacocoTestReport",
@@ -194,7 +196,16 @@ class KotlinCoreTest : FunSpec({
         }
     }
 
-    afterSpec {
-        testInstance.dispose()
+    context("When cyclonedxBom is run with this plugin") {
+
+        xtest("should work") {
+            val result = testInstance.runTask("cyclonedxBom")
+            result.output shouldContain ":cyclonedxBom"
+            result.output shouldContain "BUILD SUCCESSFUL"
+        }
+
+        afterSpec {
+            testInstance.dispose()
+        }
     }
 })

--- a/src/test/kotlin/no/elhub/devxp/KotlinLibraryTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinLibraryTest.kt
@@ -32,7 +32,8 @@ class KotlinLibraryTest : FunSpec({
                 "org.owasp.dependencycheck",
                 "org.jetbrains.dokka",
                 "com.jfrog.artifactory",
-                "maven-publish"
+                "maven-publish",
+                "org.cyclonedx.bom",
             )
 
         pluginsIncluded.forEach { plugin ->
@@ -52,7 +53,8 @@ class KotlinLibraryTest : FunSpec({
                 "jacocoTestReport",
                 "test",
                 "publish",
-                "artifactoryPublish"
+                "artifactoryPublish",
+                "cyclonedxBom",
             )
         val result = testInstance.runTask("tasks")
 

--- a/src/test/kotlin/no/elhub/devxp/KotlinServiceTest.kt
+++ b/src/test/kotlin/no/elhub/devxp/KotlinServiceTest.kt
@@ -30,7 +30,8 @@ class KotlinServiceTest : FunSpec({
                 "jacoco",
                 "com.adarshr.test-logger",
                 "org.owasp.dependencycheck",
-                "org.jetbrains.dokka"
+                "org.jetbrains.dokka",
+                "org.cyclonedx.bom",
             )
 
         pluginsIncluded.forEach { plugin ->
@@ -45,6 +46,7 @@ class KotlinServiceTest : FunSpec({
         val optionsExpected =
             arrayOf<String>(
                 "assemble",
+                "cyclonedxBom",
                 "dependencyCheckAnalyze",
                 "dependencyUpdates",
                 "jacocoTestReport",


### PR DESCRIPTION
- in the [previous PR](https://github.com/elhub/devxp-elhub-gradle-plugins/pull/161) i forgot to include [minor], so we didnt get a new version of this library (pipeline skips it if no semver change)
- add checks for cyclonedx to existing test setup
- add cyclonedxbom to build group of tasks, not functionally very important but just organises it